### PR TITLE
Fix: setBackgroundState wrong args definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ npx cap sync
 * [`getPip()`](#getpip)
 * [`setFrame(...)`](#setframe)
 * [`getFrame()`](#getframe)
+* [`setBackgroundState(...)`](#setbackgroundstate)
+* [`getBackgroundState()`](#getbackgroundstate)
 * [`setMute(...)`](#setmute)
 * [`getMute()`](#getmute)
 * [`setQuality(...)`](#setquality)
@@ -241,6 +243,30 @@ getFrame() => Promise<CapacitorFrame>
 ```
 
 **Returns:** <code>Promise&lt;<a href="#capacitorframe">CapacitorFrame</a>&gt;</code>
+
+--------------------
+
+
+### setBackgroundState(...)
+
+```typescript
+setBackgroundState(options: { backgroundState: CapacitorIvsPlayerBackgroundState; }) => Promise<void>
+```
+
+| Param         | Type                                                                                                                  |
+| ------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **`options`** | <code>{ backgroundState: <a href="#capacitorivsplayerbackgroundstate">CapacitorIvsPlayerBackgroundState</a>; }</code> |
+
+--------------------
+
+
+### getBackgroundState()
+
+```typescript
+getBackgroundState() => Promise<{ backgroundState: CapacitorIvsPlayerBackgroundState; }>
+```
+
+**Returns:** <code>Promise&lt;{ backgroundState: <a href="#capacitorivsplayerbackgroundstate">CapacitorIvsPlayerBackgroundState</a>; }&gt;</code>
 
 --------------------
 
@@ -616,6 +642,11 @@ Remove all listeners for this plugin.
 #### CapacitorIvsPlayerState
 
 <code>"IDLE" | "BUFFERING" | "READY" | "PLAYING" | "ENDED" | "UNKNOWN"</code>
+
+
+#### CapacitorIvsPlayerBackgroundState
+
+<code>"PAUSED" | "PLAYING"</code>
 
 </docgen-api>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capgo/ivs-player",
-  "version": "0.13.47",
+  "version": "0.13.50",
   "description": "Ivs player for capacitor app",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -57,7 +57,7 @@ export interface CapacitorIvsPlayerPlugin {
   }): Promise<void>;
   getFrame(): Promise<CapacitorFrame>;
   setBackgroundState(
-    backgroundState: CapacitorIvsPlayerBackgroundState,
+    options: { backgroundState: CapacitorIvsPlayerBackgroundState }
   ): Promise<void>;
   getBackgroundState(): Promise<{
     backgroundState: CapacitorIvsPlayerBackgroundState;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -56,9 +56,9 @@ export interface CapacitorIvsPlayerPlugin {
     height?: number;
   }): Promise<void>;
   getFrame(): Promise<CapacitorFrame>;
-  setBackgroundState(
-    options: { backgroundState: CapacitorIvsPlayerBackgroundState }
-  ): Promise<void>;
+  setBackgroundState(options: {
+    backgroundState: CapacitorIvsPlayerBackgroundState;
+  }): Promise<void>;
   getBackgroundState(): Promise<{
     backgroundState: CapacitorIvsPlayerBackgroundState;
   }>;

--- a/src/web.ts
+++ b/src/web.ts
@@ -72,9 +72,9 @@ export class CapacitorIvsPlayerWeb
     console.log("getPosition");
     return { x: 0, y: 0, width: 0, height: 0 };
   }
-  async setBackgroundState(
-    options: { backgroundState: CapacitorIvsPlayerBackgroundState },
-  ): Promise<void> {
+  async setBackgroundState(options: {
+    backgroundState: CapacitorIvsPlayerBackgroundState;
+  }): Promise<void> {
     console.log("setBackgroundState", options);
     return;
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -73,9 +73,9 @@ export class CapacitorIvsPlayerWeb
     return { x: 0, y: 0, width: 0, height: 0 };
   }
   async setBackgroundState(
-    backgroundState: CapacitorIvsPlayerBackgroundState,
+    options: { backgroundState: CapacitorIvsPlayerBackgroundState },
   ): Promise<void> {
-    console.log("setBackgroundState", backgroundState);
+    console.log("setBackgroundState", options);
     return;
   }
   async getBackgroundState(): Promise<{


### PR DESCRIPTION
- Fix `setBackgroundState` not able to access the value provided by the js client as it was wrongly defined.